### PR TITLE
Added support for async interceptors

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ const client = makeFetchClient({
 })
 ```
 
+Interceptors can also be async functions and will be executed in a sequential order, meaning that you can rely on previous interceptors to have been resolved. If any of the interceptors rejects the entire fetch will be rejected.
+
 ## Type usage with TypeScript
 
 The so-fetch library is fully typed and if you are using TypeScript you can take advantage of this to have a much nicer development experience. The type of a client is `SoFetch<T>`, where `T` is the response type coming from your API.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "files": ["src", "dist"],
   "jest": {
+    "testURL": "http://localhost/",
     "setupTestFrameworkScriptFile": "./test-setup.ts",
     "transform": {
       "^.+\\.tsx?$": "ts-jest"

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -2,10 +2,11 @@ import SoFetchResponse from './response'
 
 export type RequestInterceptor = (
   config: IRequestInterceptorConfig,
-) => IRequestInterceptorConfig
+) => IRequestInterceptorConfig | Promise<IRequestInterceptorConfig>
+
 export type ResponseInterceptor<T> = (
   response: SoFetchResponse<T>,
-) => SoFetchResponse<T>
+) => SoFetchResponse<T> | Promise<SoFetchResponse<T>>
 
 export interface ISoFetchInitialisation<T> {
   requestInterceptors?: RequestInterceptor[]

--- a/src/so-fetch.test.ts
+++ b/src/so-fetch.test.ts
@@ -53,6 +53,52 @@ describe('SoFetch', () => {
       return client.fetch('/fanclub').catch(fail)
     })
 
+    it('can have async request interceptors', async () => {
+      const client = new SoFetch<any>({
+        requestInterceptors: [
+          async config => {
+            config.headers = await new Headers({
+              SomeRandomHeader: 'foo',
+            })
+            return config
+          },
+        ],
+      })
+      fetchMock.getOnce('/fanclub', 200, {
+        headers: {
+          SomeRandomHeader: 'foo',
+        },
+      })
+
+      return client.fetch('/fanclub').catch(fail)
+    })
+
+    it('can have multiple async request interceptors', () => {
+      const client = new SoFetch<any>({
+        requestInterceptors: [
+          async config => {
+            config.headers = await new Headers({
+              SomeRandomHeader: 'foo',
+            })
+            return config
+          },
+          async config => {
+            const headerData = await config.headers.get('SomeRandomHeader')
+            config.headers.set('AnotherHeader', `${headerData}Bar`)
+            return config
+          },
+        ],
+      })
+      fetchMock.getOnce('/fanclub', 200, {
+        headers: {
+          SomeRandomHeader: 'foo',
+          AnotherHeader: 'fooBar',
+        },
+      })
+
+      return client.fetch('/fanclub').catch(fail)
+    })
+
     it('passes an empty headers obj if there are none', () => {
       const client = new SoFetch<any>({
         requestInterceptors: [

--- a/src/so-fetch.test.ts
+++ b/src/so-fetch.test.ts
@@ -138,6 +138,35 @@ describe('SoFetch', () => {
       })
     })
 
+    it('can have multiple async response interceptors', () => {
+      const myAsyncFn = (data: any) => Promise.resolve(data)
+      const client = new SoFetch<any>({
+        responseInterceptors: [
+          async response => {
+            // @ts-ignore
+            response.myCustomData = await myAsyncFn('first')
+            return response
+          },
+          async response => {
+            // @ts-ignore
+            response.myCustomData2 = await myAsyncFn(
+              // @ts-ignore
+              `${response.myCustomData}Second`,
+            )
+            return response
+          },
+        ],
+      })
+      fetchMock.getOnce('/fanclub', 200)
+
+      return client.fetch('/fanclub').then(response => {
+        // @ts-ignore
+        expect(response.myCustomData).toBe('first')
+        // @ts-ignore
+        expect(response.myCustomData2).toBe('firstSecond')
+      })
+    })
+
     it('gives response interceptors the final config', () => {
       const spy = jest.fn()
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es6",
     "module": "commonjs",
     "declaration": true,
     "noEmit": true,


### PR DESCRIPTION
The only (theoretical) breaking change with this PR is the fact that I explicitly use `Promise.resolve`, instead of just the implicit promises from `fetch`.  This required me to update the tsconfig to ES6 to not throw ts-errors.