### PR TITLE
fix(types): actually exposing types to outside world

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,3 +20,4 @@ export { makeFetchClient, SoFetchResponse }
 export default defaultFetch
 
 export * from './interfaces'
+export { default as SoFetch } from './so-fetch';

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,4 +20,4 @@ export { makeFetchClient, SoFetchResponse }
 export default defaultFetch
 
 export * from './interfaces'
-export { default as SoFetch } from './so-fetch';
+export { default as SoFetch } from './so-fetch'

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,3 +18,5 @@ const makeFetchClient = <T>(args: ISoFetchInitialisation<T>): SoFetch<T> =>
 export { makeFetchClient, SoFetchResponse }
 
 export default defaultFetch
+
+export * from './interfaces'


### PR DESCRIPTION
To be able to use the ts types in consuming app/lib the types need to be exported.