### PR TITLE
feat(shorthands): added shorthands for relevant http methods

### DIFF
--- a/src/so-fetch.test.ts
+++ b/src/so-fetch.test.ts
@@ -155,4 +155,79 @@ describe('SoFetch', () => {
       })
     })
   })
+
+  describe('put', () => {
+    it('puts the JSON with the right headers', () => {
+      const client = new SoFetch<any>()
+
+      fetchMock.once(
+        (url, request) => {
+          if (request.method === 'PUT' && url === '/fanclub') {
+            expect((request.headers as Headers).get('Content-Type')).toEqual(
+              'application/json',
+            )
+            return true
+          }
+          return false
+        },
+        {
+          status: 200,
+        },
+      )
+
+      return client.put('/fanclub', { name: 'Kanye West' }).then(resp => {
+        expect(resp.status).toEqual(200)
+      })
+    })
+  })
+
+  describe('patch', () => {
+    it('patches the JSON with the right headers', () => {
+      const client = new SoFetch<any>()
+
+      fetchMock.once(
+        (url, request) => {
+          if (request.method === 'PATCH' && url === '/fanclub') {
+            expect((request.headers as Headers).get('Content-Type')).toEqual(
+              'application/json',
+            )
+            return true
+          }
+          return false
+        },
+        {
+          status: 200,
+        },
+      )
+
+      return client.patch('/fanclub', { name: 'Kanye West' }).then(resp => {
+        expect(resp.status).toEqual(200)
+      })
+    })
+  })
+
+  describe('del', () => {
+    it('deletes the JSON with the right headers', () => {
+      const client = new SoFetch<any>()
+
+      fetchMock.once(
+        (url, request) => {
+          if (request.method === 'DELETE' && url === '/fanclub') {
+            expect((request.headers as Headers).get('Content-Type')).toEqual(
+              'application/json',
+            )
+            return true
+          }
+          return false
+        },
+        {
+          status: 204,
+        },
+      )
+
+      return client.del('/fanclub', { name: 'Kanye West' }).then(resp => {
+        expect(resp.status).toEqual(204)
+      })
+    })
+  })
 })

--- a/src/so-fetch.ts
+++ b/src/so-fetch.ts
@@ -70,13 +70,19 @@ class SoFetch<T> {
       })
   }
 
+  public get(url: string, options: IFetchOptions = {}) {
+    return this.fetch(url, options)
+  }
+
   public post(
     url: string,
     postBody?: {},
     options?: IFetchOptions,
   ): Promise<SoFetchResponse<T>> {
     const headers = new Headers((options && options.headers) || {})
-    headers.set('Content-Type', 'application/json')
+    if (postBody) {
+      headers.set('Content-Type', 'application/json')
+    }
 
     return this.fetch(url, {
       method: 'POST',
@@ -92,12 +98,50 @@ class SoFetch<T> {
     options?: IFetchOptions,
   ): Promise<SoFetchResponse<T>> {
     const headers = new Headers((options && options.headers) || {})
-    headers.set('Content-Type', 'application/json')
+    if (postBody) {
+      headers.set('Content-Type', 'application/json')
+    }
 
     return this.fetch(url, {
       ...options,
       method: 'PUT',
-      body: JSON.stringify(postBody),
+      body: postBody ? JSON.stringify(postBody) : undefined,
+      headers,
+    })
+  }
+
+  public patch(
+    url: string,
+    postBody?: {},
+    options?: IFetchOptions,
+  ): Promise<SoFetchResponse<T>> {
+    const headers = new Headers((options && options.headers) || {})
+    if (postBody) {
+      headers.set('Content-Type', 'application/json')
+    }
+
+    return this.fetch(url, {
+      ...options,
+      method: 'PATCH',
+      body: postBody ? JSON.stringify(postBody) : undefined,
+      headers,
+    })
+  }
+
+  public del(
+    url: string,
+    postBody?: {},
+    options?: IFetchOptions,
+  ): Promise<SoFetchResponse<T>> {
+    const headers = new Headers((options && options.headers) || {})
+    if (postBody) {
+      headers.set('Content-Type', 'application/json')
+    }
+
+    return this.fetch(url, {
+      ...options,
+      method: 'DELETE',
+      body: postBody ? JSON.stringify(postBody) : undefined,
       headers,
     })
   }


### PR DESCRIPTION
Added shorthands for remaining the http Methods (`get`, `patch`, `del`).

Also I am only setting the content-type if actually sending data, this I am open for revertion if actively disliked.