### PR TITLE
feat: #13 fetch now accepts only ifetchoptions.

### DIFF
--- a/src/so-fetch.test.ts
+++ b/src/so-fetch.test.ts
@@ -116,6 +116,20 @@ describe('SoFetch', () => {
   })
 
   describe('fetch', () => {
+    it('can be called with just an iFetchOptions', () => {
+      const client = new SoFetch<any>()
+
+      fetchMock.getOnce('/fanclub', {
+        status: 200,
+        body: { name: 'Kanye West' },
+      })
+
+      return client.fetch({ url: '/fanclub' }).then(resp => {
+        expect(resp.data).toEqual({ name: 'Kanye West' })
+        expect(resp.status).toEqual(200)
+      })
+    })
+
     it('returns the original response with an extra data property', () => {
       const client = new SoFetch<any>()
 

--- a/src/so-fetch.ts
+++ b/src/so-fetch.ts
@@ -46,9 +46,18 @@ class SoFetch<T> {
   }
 
   public fetch(
-    url: string,
+    options: string | IFetchOptions & { url: string },
+  ): Promise<SoFetchResponse<T>>
+  public fetch(url: string, options: IFetchOptions): Promise<SoFetchResponse<T>>
+
+  public fetch(
+    url: string | (IFetchOptions & { url: string }),
     options: IFetchOptions = {},
   ): Promise<SoFetchResponse<T>> {
+    if (typeof url !== 'string') {
+      options = url
+      url = url.url
+    }
     const fullUrl = this.rootUrl() + url
     const headers = new Headers(options.headers || {})
 


### PR DESCRIPTION
Fixes #13 

note:
```js
IFetchOptions & { url: string }
```
This makes the `url` mandatory in these cases.